### PR TITLE
filter is an iterator in PY3. Remove also comments.

### DIFF
--- a/ajenti-dev-multitool
+++ b/ajenti-dev-multitool
@@ -199,7 +199,7 @@ from setuptools import setup, find_packages
 
 import os
 
-__requires = filter(None, open('requirements.txt').read().splitlines())
+__requires = [dep.split('#')[0].strip() for dep in filter(None, open('requirements.txt').read().splitlines())] 
 
 setup(
     name='ajenti.plugin.%(pypi_name)s',


### PR DESCRIPTION
Requirements was not included in the last upload of plugins because `filter()` returns an iterator in PY3 and not a list as in PY2.